### PR TITLE
Docs: clarify configuration source for opnc-integration chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,20 @@ make teardown-all
 
 ## Configuring the Setup
 
-See the [environments/default/config.yaml](https://github.com/saw-jan/opnc-helm-chart/blob/master/environments/default/config.yaml) file for configuration options.
+⚠️ Do not edit `charts/opnc-integration/values.yaml` directly.
+All configuration must go into [environments/default/config.yaml](https://github.com/saw-jan/opnc-helm-chart/blob/master/environments/default/config.yaml).
+This file overrides the chart defaults and is the source of truth for deployments.
+
+### Example: Changing app version
+
+To change the version of the `integration_openproject` app in Nextcloud:
+
+```yaml
+# environments/default/config.yaml
+nextcloud:
+  extraApps:
+    - name: integration_openproject
+      version: "2.8.1"
 
 ## Serve From Git Branch
 


### PR DESCRIPTION
Explained that all configurations must be done in `environments/default/config.yaml` instead of editing `charts/opnc-integration/values.yaml`.

Added an example of changing the Nextcloud integration app version, table of config file responsibilities.